### PR TITLE
Watchers URL change

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # scraper.rb - Quick and dirty API for scraping data from FA
 #
 # Copyright (C) 2015 Erra Boothale <erra@boothale.net>
@@ -180,7 +182,7 @@ class Furaffinity
   end
 
   def login(username, password)
-    response = post('/login/', nil, {
+    response = post('/login/', {
       'action' => 'login',
       'retard_protection' => '1',
       'name' => username,
@@ -231,10 +233,9 @@ class Furaffinity
   end
 
   def budlist(name, page, is_watchers)
-    mode = is_watchers ? 'watched_by' : 'watches'
+    mode = is_watchers ? 'to' : 'by'
     html = fetch("user/#{escape(name)}")
-    id = find_id(html)
-    html = fetch("budslist/?name=#{escape(name)}&uid=#{id}&mode=#{mode}&page=#{page}")
+    html = fetch("watchlist/#{mode}/#{escape(name)}/#{page}/")
     html.css('.artist_name').map{|elem| elem.content}
   end
 


### PR DESCRIPTION
FA seems to have changed the URL for getting watchers/is watching for a user, so I made a few tweaks to handle that. The goal was to change as little of the existing code as possible. 

Additionally I kept getting errors about 3 parameters being passed to post from the login function, and removing the nil parameter fixed that. 

Finally, in older versions of ruby (versions before Ruby 2, which still ships with the current Ubuntu LTS) you get errors about an encoding mismatch in the regex, which is fixed by adding an encoding tag to the top of the file. (Ruby 2 changes the default encoding to UTF-8)

This is my first time doing anything with Ruby, so apologies in advance if I've done something horribly wrong.