### PR TITLE
Fix full and thumbnail url from 2017-03-10 FA update

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -246,7 +246,7 @@ class Furaffinity
     info = raw_info.content.lines.map{|i| i.gsub(/^\p{Space}*/, '').rstrip}
     keywords = raw_info.css('div#keywords a')
     date = pick_date(raw_info.at_css('.popup_date'))
-    urls = html.at_css('#page-submission .alt1 script').try(:content)
+    img = html.at_css('img#submissionImg')
     downloadurl = "http:" + html.css('#page-submission td.alt1 div.actions a').select {|a| a.content == "Download" }.first['href']
 
     {
@@ -258,8 +258,8 @@ class Furaffinity
       posted: date,
       posted_at: to_iso8601(date),
       download: downloadurl,
-      full: urls ? "http:#{urls[/var\s+full_url\s+=\s+"([^\s]+)";/, 1]}" : nil,
-      thumbnail: urls ? "http:#{urls[/var\s+small_url\s+=\s+"([^\s]+)";/, 1]}" : nil,
+      full: img ? "http:" + img['data-fullview-src'] : nil,
+      thumbnail: img ? "http:" + img['data-preview-src'] : nil,
       category: field(info, 'Category'),
       theme: field(info, 'Theme'),
       species: field(info, 'Species'),


### PR DESCRIPTION
As of the [recent update](https://www.furaffinity.net/journal/8120541) to Furaffinity image full view and thumbnail URLs can not be retrieved the same way as before. They are now available in the _data-fullview-src_ and _data-preview-src_ attributes of the submission img tag.

I have no experience at all with Ruby so chances are there are better ways to solve this, but this patch seems to work for me.