### PR TITLE
Fixing a typo in a cache key name

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -456,7 +456,7 @@ class Furaffinity
       end
     end
 
-    raw, uri = @cache.add("url:serach:#{params.to_s}") do
+    raw, uri = @cache.add("url:search:#{params.to_s}") do
       response, uri = post('/search/', params)
       unless response.is_a?(Net::HTTPSuccess)
         raise FAStatusError.new(fa_url('search/'), response.message)


### PR DESCRIPTION
"serach" -> "search"