### PR TITLE
Comment cleaning

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -655,7 +655,7 @@ private
           avatar: "http:#{comment.at_css('.icon img')['src']}",
           posted: date,
           posted_at: to_iso8601(date),
-          text: comment.at_css('.replyto-message').children.to_s.strip.gsub(/ <br><br>$/, ''),
+          text: comment.at_css('.message-text').children.to_s.strip,
           reply_to: reply_to,
           reply_level: reply_level
         }


### PR DESCRIPTION
I don't know if this is something that's actually wanted, or the opposite of that.

The docs seem to suggest that it shouldn't contain the `<div class=\"message-text\">` stuff, and that's all newer on FA, so it wasn't built with those divs in mind.

Basically, if the current functionality, including the `<div class=\"message-text\">` is intended, feel free to close this one