### PR TITLE
Notes endpoints

### DIFF
--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -55,7 +55,7 @@ module FAExport
     USER_REGEX = /((?:[a-zA-Z0-9\-_~.]|%5B|%5D|%60)+)/
     ID_REGEX = /([0-9]+)/
     COOKIE_REGEX = /^b=[a-z0-9\-]+; a=[a-z0-9\-]+$/
-    NOTE_FOLDER_REGEX = /(inbox|outbox)/
+    NOTE_FOLDER_REGEX = /(inbox|outbox|unread|archive|trash|high|medium|low)/
 
     def initialize(app, config = {})
       FAExport.config = config.with_indifferent_access

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -714,6 +714,63 @@ class Furaffinity
     }
   end
 
+  def note(id)
+    html = fetch("msg/pms/1/#{id}/")
+    current_user = get_current_user(html)
+    note_table = html.at_css(".note-view-container table.maintable table.maintable")
+    # date = pick_date(html.at_css('td.cat .journal-title-box .popup_date'))
+    # profile_url = html.at_css('td.cat .journal-title-box a')['href'][1..-1]
+    # journal_header = html.at_css('.journal-header').children[0..-3].to_s.strip unless html.at_css('.journal-header').nil?
+    # journal_footer = html.at_css('.journal-footer').children[2..-1].to_s.strip unless html.at_css('.journal-footer').nil?
+    #
+    # {
+    #     title: html.at_css('td.cat b').content.gsub(/\A[[:space:]]+|[[:space:]]+\z/, ''),
+    #     description: html.at_css('td.alt1 div.no_overflow').children.to_s.strip,
+    #     journal_header: journal_header,
+    #     journal_body: html.at_css('.journal-body').children.to_s.strip,
+    #     journal_footer: journal_footer,
+    #     name: html.at_css('td.cat .journal-title-box a').content,
+    #     profile: fa_url(profile_url),
+    #     profile_name: last_path(profile_url),
+    #     avatar: "https:#{html.at_css("img.avatar")['src']}",
+    #     link: fa_url("journal/#{id}/"),
+    #     posted: date,
+    #     posted_at: to_iso8601(date)
+    # }
+    note_header = note_table.at_css("td.head")
+    note_from = note_header.css("em")[1].at_css("a")
+    note_to = note_header.css("em")[2].at_css("a")
+    is_inbound = current_user[:profile_name] == last_path(note_to['href'])
+    profile = is_inbound ? note_from : note_to
+    date = pick_date(note_table.at_css("span.popup_date"))
+    description = note_table.at_css("td.text")
+    desc_split = description.inner_html.split("—————————")
+    {
+        note_id: id,
+        subject: note_header.at_css("em.title").content,
+        is_inbound: is_inbound,
+        name: profile.content,
+        profile: fa_url(profile['href'][1..-1]),
+        profile_name: last_path(profile['href']),
+        posted: date,
+        posted_at: to_iso8601(date),
+        avatar: "https#{note_table.at_css("img.avatar")['src']}",
+        description: description.inner_html.strip,
+        description_body: html_strip(desc_split.first.strip),
+        preceeding_notes: desc_split[1..-1].map do |note|
+          note_html = Nokogiri::HTML(note)
+          profile = note_html.at_css("a.linkusername")
+          {
+              name: profile.content.to_s,
+              profile: fa_url(profile['href'][1..-1]),
+              profile_name: last_path(profile['href']),
+              description: note,
+              description_body: html_strip(note.to_s.split("</a>:")[1..-1].join("</a>:"))
+          }
+        end
+    }
+  end
+
   def fa_url(path)
     if path.to_s.start_with? "/"
       path = path[1..-1]
@@ -724,6 +781,10 @@ class Furaffinity
 private
   def fa_address
     "https://#{safe_for_work ? 'sfw' : 'www'}.furaffinity.net"
+  end
+
+  def html_strip(html_s)
+    html_s.gsub(/^(<br ?\/?>|\\r|\\n|\s)+/, "").gsub(/(<br ?\/?>|\\r|\\n|\s)+$/,"")
   end
 
   def last_path(path)

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -735,14 +735,12 @@ class Furaffinity
       if profile_to.nil?
         is_inbound = true
         profile = profile_from.at_css("a")
+      elsif profile_from.nil?
+        is_inbound = false
+        profile = profile_to.at_css("a")
       else
-        if profile_from.nil?
-          is_inbound = false
-          profile = profile_to.at_css("a")
-        else
-          is_inbound = profile_to.content.strip == "me"
-          profile = is_inbound ? profile_from.at_css("a") : profile_to.at_css("a")
-        end
+        is_inbound = profile_to.content.strip == "me"
+        profile = is_inbound ? profile_from.at_css("a") : profile_to.at_css("a")
       end
       {
           note_id: note.at_css("input")['value'],

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -718,25 +718,6 @@ class Furaffinity
     html = fetch("msg/pms/1/#{id}/")
     current_user = get_current_user(html)
     note_table = html.at_css(".note-view-container table.maintable table.maintable")
-    # date = pick_date(html.at_css('td.cat .journal-title-box .popup_date'))
-    # profile_url = html.at_css('td.cat .journal-title-box a')['href'][1..-1]
-    # journal_header = html.at_css('.journal-header').children[0..-3].to_s.strip unless html.at_css('.journal-header').nil?
-    # journal_footer = html.at_css('.journal-footer').children[2..-1].to_s.strip unless html.at_css('.journal-footer').nil?
-    #
-    # {
-    #     title: html.at_css('td.cat b').content.gsub(/\A[[:space:]]+|[[:space:]]+\z/, ''),
-    #     description: html.at_css('td.alt1 div.no_overflow').children.to_s.strip,
-    #     journal_header: journal_header,
-    #     journal_body: html.at_css('.journal-body').children.to_s.strip,
-    #     journal_footer: journal_footer,
-    #     name: html.at_css('td.cat .journal-title-box a').content,
-    #     profile: fa_url(profile_url),
-    #     profile_name: last_path(profile_url),
-    #     avatar: "https:#{html.at_css("img.avatar")['src']}",
-    #     link: fa_url("journal/#{id}/"),
-    #     posted: date,
-    #     posted_at: to_iso8601(date)
-    # }
     note_header = note_table.at_css("td.head")
     note_from = note_header.css("em")[1].at_css("a")
     note_to = note_header.css("em")[2].at_css("a")

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -724,9 +724,38 @@ class Furaffinity
         high: "high_prio",
         medium: "medium_prio",
         low: "low_prio"
-    }[folder]
+    }[folder.to_sym]
     html = fetch("msg/pms/", "folder=#{note_cookie}")
-    # TODO: parse
+    notes_table = html.at_css("table#notes-list")
+    notes_table.css("tr.note").map do |note|
+      subject = note.at_css("td.subject")
+      profile_from = note.at_css("td.col-from")
+      profile_to = note.at_css("td.col-to")
+      date = pick_date(note.at_css("span.popup_date"))
+      if profile_to.nil?
+        is_inbound = true
+        profile = profile_from.at_css("a")
+      else
+        if profile_from.nil?
+          is_inbound = false
+          profile = profile_to.at_css("a")
+        else
+          is_inbound = profile_to.content.strip == "me"
+          profile = is_inbound ? profile_from.at_css("a") : profile_to.at_css("a")
+        end
+      end
+      {
+          note_id: note.at_css("input")['value'],
+          subject: subject.at_css("a.notelink").content,
+          is_inbound: is_inbound,
+          is_read: subject.at_css("img.unread").nil?,
+          name: profile.content,
+          profile: fa_url(profile['href'][1..-1]),
+          profile_name: last_path(profile['href']),
+          posted: date,
+          posted_at: to_iso8601(date)
+      }
+    end
   end
 
   def note(id)

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -714,6 +714,21 @@ class Furaffinity
     }
   end
 
+  def notes(folder)
+    note_cookie = {
+        inbox: "inbox",
+        outbox: "outbox",
+        unread: "unread",
+        archive: "archive",
+        trash: "trash",
+        high: "high_prio",
+        medium: "medium_prio",
+        low: "low_prio"
+    }[folder]
+    html = fetch("msg/pms/", "folder=#{note_cookie}")
+    # TODO: parse
+  end
+
   def note(id)
     html = fetch("msg/pms/1/#{id}/")
     current_user = get_current_user(html)
@@ -842,10 +857,10 @@ private
     CGI::escape(name)
   end
 
-  def fetch(path)
+  def fetch(path, extra_cookie = nil)
     url = fa_url(path)
-    raw = @cache.add("url:#{url}") do
-      open(url, 'User-Agent' => USER_AGENT, 'Cookie' => @login_cookie) do |response|
+    raw = @cache.add("url:#{url}:#{extra_cookie}") do
+      open(url, 'User-Agent' => USER_AGENT, 'Cookie' => "#{@login_cookie};#{extra_cookie}") do |response|
         if response.status[0] != '200'
           raise FAStatusError.new(url, response.status.join(' '))
         end

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -812,6 +812,7 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
   {
     "note_id": 123,
     "subject": "No subject",
+    "is_inbound": true,
     "is_read": false,
     "name": "John Oliver",
     "profile_name": "https://furaffinity.net/user/john_oliver/",

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -810,9 +810,9 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
 ~~~json
 [
   {
-    "note_id": 0123,
+    "note_id": 123,
     "subject": "No subject",
-    "is_read": False,
+    "is_read": false,
     "name": "John Oliver",
     "profile_name": "https://furaffinity.net/user/john_oliver/",
     "profile": "john_oliver",
@@ -833,16 +833,16 @@ Views a specific note.
 
 ~~~json
 {
-  "note_id": 0123,
+  "note_id": 125,
   "subject": "Re: No subject",
-  "is_inbound": True,
+  "is_inbound": true,
   "name": "John Oliver",
   "profile_name": "https://furaffinity.net/user/john_oliver/",
   "profile": "john_oliver",
   "posted": "on May 3rd, 2019 01:04 PM",
   "posted_at": "2019-05-03T13:04:00Z",
   "description": "Not really. How are you?",
-  "earlier_notes": [
+  "preceeding_notes": [
     {
       "name": "Fender",
       "profile_name": "https://furaffinity.net/user/fender/",

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -841,7 +841,8 @@ Views a specific note.
   "profile": "john_oliver",
   "posted": "on May 3rd, 2019 01:04 PM",
   "posted_at": "2019-05-03T13:04:00Z",
-  "description": "Not really. How are you?",
+  "description": "Not really. How are you?\n\n______<snip>",
+  "description_body": "Not really. How are you?",
   "preceeding_notes": [
     {
       "name": "Fender",

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -823,7 +823,7 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
 ]
 ~~~
 
-### GET /notes/{id}
+### GET /note/{id}
 
 *Formats:* `json`, `xml`
 

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -799,6 +799,66 @@ To include deleted notifications as well, pass `?include_deleted=1`.
 }
 ~~~
 
+### GET /notes/{folder}
+
+*Formats:* `json`, `xml`, `rss`
+
+Login cookie required.
+
+Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox`, `unread`, `archive`, `trash`, `high`, `medium`, or `low`.
+
+~~~json
+[
+  {
+    "note_id": 0123,
+    "subject": "No subject",
+    "is_read": False,
+    "name": "John Oliver",
+    "profile_name": "https://furaffinity.net/user/john_oliver/",
+    "profile": "john_oliver",
+    "posted": "on May 3rd, 2019 01:04 PM",
+    "posted_at": "2019-05-03T13:04:00Z"
+  },
+  <snip>
+]
+~~~
+
+### GET /notes/{id}
+
+*Formats:* `json`, `xml`
+
+Login cookie required.
+
+Views a specific note.
+
+~~~json
+{
+  "note_id": 0123,
+  "subject": "Re: No subject",
+  "is_inbound": True,
+  "name": "John Oliver",
+  "profile_name": "https://furaffinity.net/user/john_oliver/",
+  "profile": "john_oliver",
+  "posted": "on May 3rd, 2019 01:04 PM",
+  "posted_at": "2019-05-03T13:04:00Z",
+  "description": "Not really. How are you?",
+  "earlier_notes": [
+    {
+      "name": "Fender",
+      "profile_name": "https://furaffinity.net/user/fender/",
+      "profile": "fender",
+      "description": "Hey, do u rp?"
+    },
+    {
+      "name": "John Oliver",
+      "profile_name": "https://furaffinity.net/user/john_oliver/",
+      "profile": "john_oliver",
+      "description": "Hello there!"
+    }
+  ]
+}
+~~~
+
 ### POST /journal
 
 *Formats:* `json`, `query`

--- a/lib/faexport/views/index.haml
+++ b/lib/faexport/views/index.haml
@@ -59,3 +59,16 @@
     %dd
       %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notifications/#{notification_type}.rss"}
       %br
+  %dt Notes (login cookie required)
+  %dd
+    - %w(json xml rss).map do |type|
+      - %w(inbox unread outbox high medium low archive trash).map do |folder|
+        %dd
+          %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notes/#{folder}.#{type}"}
+          %br
+  %dt Note view (login cookie required)
+  %dd
+    - %w(json xml).map do |type|
+      %dd
+        %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/note/{id}.#{type}"}
+        %br


### PR DESCRIPTION
That was reasonably speedy.
Adds /notes/{folder} endpoints, and /note/{id} endpoints.

Things I'm not terribly confident on:
- Note rss feed saying a note is received, when it might not be following inbox
- Hash[string.to_sym] in notes to convert API name to FA name for notes folders
- My changes to fetch() to add extra_cookie argument