### PR TITLE
Add support for automatic CSS dark mode

### DIFF
--- a/lib/faexport/public/css/faexport.css
+++ b/lib/faexport/public/css/faexport.css
@@ -1,3 +1,6 @@
+:root {
+  color-scheme: light dark;
+}
 h1 {
     margin-bottom: 0;
 }
@@ -40,7 +43,7 @@ dd {
 
 #menu a {
     text-decoration: none;
-    color: #000000;
+    color: CanvasText;
 }
 
 #menu a:hover {


### PR DESCRIPTION
This change uses the CSS color-scheme property (widely available as of 2022 according to MDN [^1]) to opt FAExport's web interface in to automatic CSS light and dark mode.  This change should be invisible to browsers that do not support `color-scheme`, since it has no other effects, and browsers that do not support the property will continue to display FAExport in light mode, as they always have.

In order to make the navigation links visible in dark mode, I also changed the text color from `#000000` to `CanvasText`, which selects the default text color.  This color name has been available since 2015, according to MDN [^2].  If you'd prefer, I can add the `CanvasText` line after the original `#000000` line, so that browsers which do not support the system-color data type will still display the links in black text. (That shouldn't be an issue for dark mode, since a browser that doesn't support system-color will almost certainly not support `color-scheme` :P)

[^1]: https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/system-color

Motivation: I got flashbanged by FAExport at 2:30 am and realized that I could fix that :3